### PR TITLE
FindAllStats: Fix to get the json of resource when not an array

### DIFF
--- a/service/stats.go
+++ b/service/stats.go
@@ -39,10 +39,17 @@ func (c *NitroClient) FindAllStats(resourceType string) ([]map[string]interface{
 		log.Printf("[WARN] nitro-go: FindStats No %s type found", resourceType)
 		return nil, fmt.Errorf("[INFO] nitro-go: FindStats: No type of %s found", resourceType)
 	}
-	resources := data[resourceType].([]interface{})
-	ret := make([]map[string]interface{}, len(resources), len(resources))
-	for i, v := range resources {
-		ret[i] = v.(map[string]interface{})
+	ret := make([]map[string]interface{}, 0)
+	switch data[resourceType].(type) {
+	case []interface{}:
+		resources := data[resourceType].([]interface{})
+		ret = make([]map[string]interface{}, len(resources), len(resources))
+		for i, v := range resources {
+			ret[i] = v.(map[string]interface{})
+		}
+	case map[string]interface{}:
+		resources := data[resourceType].(map[string]interface{})
+		ret = append(ret, resources)
 	}
 	return ret, nil
 }


### PR DESCRIPTION
The FindAllStats function was implemented with the condition that the json resource tag contains an array,
so it has been modified to handle `[]interface{}` or `map[string]interface{}` in the type evaluation