### PR TITLE
fix(FindAllResources): handle single-object responses without panic

### DIFF
--- a/service/config.go
+++ b/service/config.go
@@ -737,14 +737,22 @@ func (c *NitroClient) FindAllResources(resourceType string) ([]map[string]interf
 		c.logger.Trace(" FindAllResources: resource not found", "resourceType", resourceType)
 		return make([]map[string]interface{}, 0, 0), nil
 	}
-	resources := data[resourceType].([]interface{})
-
-	ret := make([]map[string]interface{}, len(resources), len(resources))
-	for i, v := range resources {
-		ret[i] = v.(map[string]interface{})
+	// The NITRO API returns a JSON array for most resource types, but a few
+	// (e.g. nsversion) return a single JSON object. Guard against the panic
+	// that occurs when the type assertion to []interface{} fails.
+	switch v := rsrcs.(type) {
+	case []interface{}:
+		ret := make([]map[string]interface{}, len(v))
+		for i, item := range v {
+			ret[i] = item.(map[string]interface{})
+		}
+		return ret, nil
+	case map[string]interface{}:
+		return []map[string]interface{}{v}, nil
+	default:
+		c.logger.Warn("FindAllResources: unexpected response shape", "resourceType", resourceType)
+		return make([]map[string]interface{}, 0, 0), nil
 	}
-
-	return ret, nil
 }
 
 // ResourceBindingExists returns true if the supplied binding exists


### PR DESCRIPTION
The NITRO API returns a JSON array for most resource types, but some (e.g. nsversion) return a single JSON object. The hard type assertion on line 740:

    resources := data[resourceType].([]interface{})

panics with "interface conversion: interface {} is map[string]interface {}, not []interface {}" when the value is a plain object.

Replace the assertion with a type switch that handles:
  - []interface{}         → existing array path (unchanged behaviour)
  - map[string]interface{} → wrap in a single-element slice
  - anything else          → return empty slice with a warning log