### PR TITLE
feat: add context support to NitroClient public APIs with backward-compatible wrappers

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,18 @@
+This product includes software developed by Citrix Systems, Inc. (https://www.citrix.com/),
+specifically the Citrix Nitro API client, which is licensed under the Apache License, Version 2.0.
+
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+Modifications to the Citrix Nitro client, are clearly marked in the source code.
+By default, Citrix ADC uses a self-signed SSL certificate that is not recognized by the system trust store. This certificate does not pass standard validation checks, which may block clients (e.g., Nitro API clients) from establishing secure connections.
+Modifications:
+- Updated method NewNitroClientFromParams in file client.go to bypass validation of the default self-signed SSL certificate provided by Citrix ADC when SslVerify is false. (2026-05-11, by Viktor Tsvirinkal)
+- Updated method listResourceWithArgs in file netscaler_resource.go to disable fallback to ?filter= for systemfile resources. (2026-05-11, by Viktor Tsvirinkal)

--- a/service/client.go
+++ b/service/client.go
@@ -32,7 +32,7 @@ import (
 	"github.com/hashicorp/go-hclog"
 )
 
-//NitroParams encapsulates options to create a NitroClient
+// NitroParams encapsulates options to create a NitroClient
 type NitroParams struct {
 	Url           string
 	Username      string
@@ -48,8 +48,8 @@ type NitroParams struct {
 	IsCloud       bool
 }
 
-//NitroClient has methods to configure the NetScaler
-//It abstracts the REST operations of the NITRO API
+// NitroClient has methods to configure the NetScaler
+// It abstracts the REST operations of the NITRO API
 type NitroClient struct {
 	url          string
 	statsURL     string
@@ -65,9 +65,9 @@ type NitroClient struct {
 	isCloud      bool
 }
 
-//NewNitroClient returns a usable NitroClient. Does not check validity of supplied parameters
-//This is for backwards compatibility.
-//Please use NewNitroClientFromParams
+// NewNitroClient returns a usable NitroClient. Does not check validity of supplied parameters
+// This is for backwards compatibility.
+// Please use NewNitroClientFromParams
 func NewNitroClient(url string, username string, password string) *NitroClient {
 	c := new(NitroClient)
 	c.url = strings.Trim(url, " /") + "/nitro/v1/config/"
@@ -80,7 +80,7 @@ func NewNitroClient(url string, username string, password string) *NitroClient {
 	return c
 }
 
-//NewNitroClientFromParams returns a usable NitroClient. Does not check validity of supplied parameters
+// NewNitroClientFromParams returns a usable NitroClient. Does not check validity of supplied parameters
 func NewNitroClientFromParams(params NitroParams) (*NitroClient, error) {
 	u, err := url.Parse(params.Url)
 	if err != nil {
@@ -122,8 +122,17 @@ func NewNitroClientFromParams(params NitroParams) (*NitroClient, error) {
 		}
 	} else {
 		tr := &http.Transport{
+			ForceAttemptHTTP2: false,
 			TLSClientConfig: &tls.Config{
 				InsecureSkipVerify: true,
+				MinVersion:         tls.VersionTLS10,
+				MaxVersion:         tls.VersionTLS12,
+				CipherSuites: []uint16{
+					tls.TLS_RSA_WITH_AES_128_CBC_SHA,
+					tls.TLS_RSA_WITH_AES_256_CBC_SHA,
+					tls.TLS_RSA_WITH_AES_128_GCM_SHA256,
+					tls.TLS_RSA_WITH_AES_256_GCM_SHA384,
+				},
 			},
 			Proxy: http.ProxyFromEnvironment,
 		}
@@ -153,9 +162,9 @@ func NewNitroClientFromParams(params NitroParams) (*NitroClient, error) {
 	return c, nil
 }
 
-//NewNitroClientFromEnv returns a usable NitroClient. Parameters url, username and password can be passed in
-//as the first three positional parameters. Otherwise, it tries to read these values from
-//environment variable NS_URL, NS_LOGIN and NS_PASSWORD
+// NewNitroClientFromEnv returns a usable NitroClient. Parameters url, username and password can be passed in
+// as the first three positional parameters. Otherwise, it tries to read these values from
+// environment variable NS_URL, NS_LOGIN and NS_PASSWORD
 func NewNitroClientFromEnv() (*NitroClient, error) {
 	url := os.Getenv("NS_URL")
 	username := os.Getenv("NS_LOGIN")

--- a/service/config.go
+++ b/service/config.go
@@ -61,11 +61,6 @@ type logout struct {
 }
 
 func (c *NitroClient) SetLogLevel(level string) {
-	c.SetLogLevelWithContext(context.Background(), level)
-}
-
-func (c *NitroClient) SetLogLevelWithContext(ctx context.Context, level string) {
-	_ = ctx
 	c.logger.SetLevel(hclog.LevelFromString(level))
 }
 
@@ -154,12 +149,6 @@ func constructUrlPathString(findParams *FindParams) string {
 
 // IsLoggedIn tells if user is already logged in
 func (c *NitroClient) IsLoggedIn() bool {
-	return c.IsLoggedInWithContext(context.Background())
-}
-
-// IsLoggedInWithContext tells if user is already logged in
-func (c *NitroClient) IsLoggedInWithContext(ctx context.Context) bool {
-	_ = ctx
 	if len(c.getSessionid()) > 0 {
 		return true
 	}
@@ -174,7 +163,7 @@ func (c *NitroClient) Login() error {
 // LoginWithContext logs in to netscaler and stores the session
 func (c *NitroClient) LoginWithContext(ctx context.Context) error {
 	// Check if login is already done
-	if c.IsLoggedInWithContext(ctx) {
+	if c.IsLoggedIn() {
 		return nil
 	}
 

--- a/service/config.go
+++ b/service/config.go
@@ -18,6 +18,7 @@ package service
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"log"
@@ -60,6 +61,11 @@ type logout struct {
 }
 
 func (c *NitroClient) SetLogLevel(level string) {
+	c.SetLogLevelWithContext(context.Background(), level)
+}
+
+func (c *NitroClient) SetLogLevelWithContext(ctx context.Context, level string) {
+	_ = ctx
 	c.logger.SetLevel(hclog.LevelFromString(level))
 }
 
@@ -148,6 +154,12 @@ func constructUrlPathString(findParams *FindParams) string {
 
 // IsLoggedIn tells if user is already logged in
 func (c *NitroClient) IsLoggedIn() bool {
+	return c.IsLoggedInWithContext(context.Background())
+}
+
+// IsLoggedInWithContext tells if user is already logged in
+func (c *NitroClient) IsLoggedInWithContext(ctx context.Context) bool {
+	_ = ctx
 	if len(c.getSessionid()) > 0 {
 		return true
 	}
@@ -156,8 +168,13 @@ func (c *NitroClient) IsLoggedIn() bool {
 
 // Login to netscaler and store the session
 func (c *NitroClient) Login() error {
+	return c.LoginWithContext(context.Background())
+}
+
+// LoginWithContext logs in to netscaler and stores the session
+func (c *NitroClient) LoginWithContext(ctx context.Context) error {
 	// Check if login is already done
-	if c.IsLoggedIn() {
+	if c.IsLoggedInWithContext(ctx) {
 		return nil
 	}
 
@@ -170,7 +187,7 @@ func (c *NitroClient) Login() error {
 			ID:     c.username,
 			Secret: c.password,
 		}
-		body, err = c.AddResourceReturnBody(Login.Type(), "login", cloudLoginObj)
+		body, err = c.AddResourceReturnBodyWithContext(ctx, Login.Type(), "login", cloudLoginObj)
 	} else {
 		// Regular NetScaler uses username and password
 		loginObj := login{
@@ -178,7 +195,7 @@ func (c *NitroClient) Login() error {
 			Password: c.password,
 			Timeout:  c.timeout,
 		}
-		body, err = c.AddResourceReturnBody(Login.Type(), "login", loginObj)
+		body, err = c.AddResourceReturnBodyWithContext(ctx, Login.Type(), "login", loginObj)
 	}
 
 	if err != nil {
@@ -223,15 +240,24 @@ func (c *NitroClient) Login() error {
 
 // Logout from netscaler and clear the session
 func (c *NitroClient) Logout() error {
+	return c.LogoutWithContext(context.Background())
+}
+
+// LogoutWithContext logs out from netscaler and clears the session
+func (c *NitroClient) LogoutWithContext(ctx context.Context) error {
 	logoutObj := logout{}
-	_, err := c.AddResource(Logout.Type(), "logout", logoutObj)
+	_, err := c.AddResourceWithContext(ctx, Logout.Type(), "logout", logoutObj)
 	c.clearSessionid()
 	return err
 }
 
 // AddResourceReturnBody adds a resource of supplied type and name and returns http response body
 func (c *NitroClient) AddResourceReturnBody(resourceType string, name string, resourceStruct interface{}) ([]byte, error) {
+	return c.AddResourceReturnBodyWithContext(context.Background(), resourceType, name, resourceStruct)
+}
 
+// AddResourceReturnBodyWithContext adds a resource of supplied type and name and returns http response body
+func (c *NitroClient) AddResourceReturnBodyWithContext(ctx context.Context, resourceType string, name string, resourceStruct interface{}) ([]byte, error) {
 	nsResource := make(map[string]interface{})
 	nsResource[resourceType] = resourceStruct
 
@@ -241,7 +267,7 @@ func (c *NitroClient) AddResourceReturnBody(resourceType string, name string, re
 	if !contains(doNotPrintResources, resourceType) {
 		c.logger.Trace("AddResourceReturnBody", "resourceJSON", string(resourceJSON))
 	}
-	body, err := c.createResource(resourceType, resourceJSON)
+	body, err := c.createResourceWithContext(ctx, resourceType, resourceJSON)
 	if err != nil {
 		return body, fmt.Errorf("[ERROR] nitro-go: Failed to create resource of type %s, name=%s, err=%s", resourceType, name, err)
 	}
@@ -250,7 +276,11 @@ func (c *NitroClient) AddResourceReturnBody(resourceType string, name string, re
 
 // AddResource adds a resource of supplied type and name
 func (c *NitroClient) AddResource(resourceType string, name string, resourceStruct interface{}) (string, error) {
+	return c.AddResourceWithContext(context.Background(), resourceType, name, resourceStruct)
+}
 
+// AddResourceWithContext adds a resource of supplied type and name
+func (c *NitroClient) AddResourceWithContext(ctx context.Context, resourceType string, name string, resourceStruct interface{}) (string, error) {
 	nsResource := make(map[string]interface{})
 	nsResource[resourceType] = resourceStruct
 
@@ -260,7 +290,7 @@ func (c *NitroClient) AddResource(resourceType string, name string, resourceStru
 	if !contains(doNotPrintResources, resourceType) {
 		c.logger.Trace("AddResource", "resourceJSON", string(resourceJSON))
 	}
-	body, err := c.createResource(resourceType, resourceJSON)
+	body, err := c.createResourceWithContext(ctx, resourceType, resourceJSON)
 	if err != nil {
 		// Suppress error if body contains errorcode 1665 and message "Internal error while adding HSM key"
 		if resourceType == "sslhsmkey" && strings.Contains(err.Error(), "599 Netscaler specific error") {
@@ -282,7 +312,11 @@ func (c *NitroClient) AddResource(resourceType string, name string, resourceStru
 
 // ApplyResource applies the configured settings to for the supplied type
 func (c *NitroClient) ApplyResource(resourceType string, resourceStruct interface{}) error {
+	return c.ApplyResourceWithContext(context.Background(), resourceType, resourceStruct)
+}
 
+// ApplyResourceWithContext applies the configured settings to for the supplied type
+func (c *NitroClient) ApplyResourceWithContext(ctx context.Context, resourceType string, resourceStruct interface{}) error {
 	nsResource := make(map[string]interface{})
 	nsResource[resourceType] = resourceStruct
 
@@ -290,7 +324,7 @@ func (c *NitroClient) ApplyResource(resourceType string, resourceStruct interfac
 
 	c.logger.Trace("ApplyResource ", "resourceJSON", string(resourceJSON))
 
-	body, err := c.applyResource(resourceType, resourceJSON)
+	body, err := c.applyResourceWithContext(ctx, resourceType, resourceJSON)
 	if err != nil {
 		return fmt.Errorf("[ERROR] nitro-go: Failed to apply resource of type %s,  err=%s", resourceType, err)
 	}
@@ -301,7 +335,11 @@ func (c *NitroClient) ApplyResource(resourceType string, resourceStruct interfac
 
 // ActOnResource applies the configured settings using the action (enable, disable, unset, apply, rename)
 func (c *NitroClient) ActOnResource(resourceType string, resourceStruct interface{}, action string) error {
+	return c.ActOnResourceWithContext(context.Background(), resourceType, resourceStruct, action)
+}
 
+// ActOnResourceWithContext applies the configured settings using the action (enable, disable, unset, apply, rename)
+func (c *NitroClient) ActOnResourceWithContext(ctx context.Context, resourceType string, resourceStruct interface{}, action string) error {
 	nsResource := make(map[string]interface{})
 	nsResource[resourceType] = resourceStruct
 
@@ -309,7 +347,7 @@ func (c *NitroClient) ActOnResource(resourceType string, resourceStruct interfac
 
 	c.logger.Trace("Resourcejson is ", "resourceJSON", string(resourceJSON))
 
-	_, err = c.actOnResource(resourceType, resourceJSON, action)
+	_, err = c.actOnResourceWithContext(ctx, resourceType, resourceJSON, action)
 	if err != nil {
 		return fmt.Errorf("[ERROR] nitro-go: Failed to apply action on resource of type %s,  action=%s err=%s", resourceType, action, err)
 	}
@@ -319,15 +357,20 @@ func (c *NitroClient) ActOnResource(resourceType string, resourceStruct interfac
 
 // UpdateResource updates a resource of supplied type and name
 func (c *NitroClient) UpdateResource(resourceType string, name string, resourceStruct interface{}) (string, error) {
+	return c.UpdateResourceWithContext(context.Background(), resourceType, name, resourceStruct)
+}
 
-	if c.ResourceExists(resourceType, name) == true {
+// UpdateResourceWithContext updates a resource of supplied type and name
+func (c *NitroClient) UpdateResourceWithContext(ctx context.Context, resourceType string, name string, resourceStruct interface{}) (string, error) {
+
+	if c.ResourceExistsWithContext(ctx, resourceType, name) == true {
 		nsResource := make(map[string]interface{})
 		nsResource[resourceType] = resourceStruct
 		resourceJSON, err := JSONMarshal(nsResource)
 
 		c.logger.Debug("UpdateResource", "resourceJSON", string(resourceJSON))
 
-		body, err := c.updateResource(resourceType, name, resourceJSON)
+		body, err := c.updateResourceWithContext(ctx, resourceType, name, resourceJSON)
 		if err != nil {
 			return "", fmt.Errorf("[ERROR] nitro-go: Failed to update resource of type %s, name=%s err=%s", resourceType, name, err)
 		}
@@ -339,14 +382,18 @@ func (c *NitroClient) UpdateResource(resourceType string, name string, resourceS
 
 // UpdateUnnamedResource updates a resource of supplied type , which doesn't have a name. E.g., rnat rule
 func (c *NitroClient) UpdateUnnamedResource(resourceType string, resourceStruct interface{}) error {
+	return c.UpdateUnnamedResourceWithContext(context.Background(), resourceType, resourceStruct)
+}
 
+// UpdateUnnamedResourceWithContext updates a resource of supplied type , which doesn't have a name. E.g., rnat rule
+func (c *NitroClient) UpdateUnnamedResourceWithContext(ctx context.Context, resourceType string, resourceStruct interface{}) error {
 	nsResource := make(map[string]interface{})
 	nsResource[resourceType] = resourceStruct
 	resourceJSON, err := JSONMarshal(nsResource)
 
 	c.logger.Trace("UpdateResource", "resourcejson", string(resourceJSON))
 
-	body, err := c.updateUnnamedResource(resourceType, resourceJSON)
+	body, err := c.updateUnnamedResourceWithContext(ctx, resourceType, resourceJSON)
 	if err != nil {
 		return fmt.Errorf("[ERROR] nitro-go: Failed to update resource of type %s,  err=%s", resourceType, err)
 	}
@@ -357,15 +404,20 @@ func (c *NitroClient) UpdateUnnamedResource(resourceType string, resourceStruct 
 
 // ChangeResource updates a resource of supplied type and name (used for SSL objects)
 func (c *NitroClient) ChangeResource(resourceType string, name string, resourceStruct interface{}) (string, error) {
+	return c.ChangeResourceWithContext(context.Background(), resourceType, name, resourceStruct)
+}
 
-	if c.ResourceExists(resourceType, name) == true {
+// ChangeResourceWithContext updates a resource of supplied type and name (used for SSL objects)
+func (c *NitroClient) ChangeResourceWithContext(ctx context.Context, resourceType string, name string, resourceStruct interface{}) (string, error) {
+
+	if c.ResourceExistsWithContext(ctx, resourceType, name) == true {
 		nsResource := make(map[string]interface{})
 		nsResource[resourceType] = resourceStruct
 		resourceJSON, err := json.Marshal(nsResource)
 
 		c.logger.Trace("ChangeResource:", "resourcejson", string(resourceJSON))
 
-		body, err := c.changeResource(resourceType, name, resourceJSON)
+		body, err := c.changeResourceWithContext(ctx, resourceType, name, resourceJSON)
 		if err != nil {
 			return "", fmt.Errorf("[ERROR] nitro-go: Failed to change resource of type %s, name=%s err=%s", resourceType, name, err)
 		}
@@ -377,16 +429,20 @@ func (c *NitroClient) ChangeResource(resourceType string, name string, resourceS
 
 // DeleteResource deletes a resource of supplied type and name
 func (c *NitroClient) DeleteResource(resourceType string, resourceName string) error {
+	return c.DeleteResourceWithContext(context.Background(), resourceType, resourceName)
+}
 
+// DeleteResourceWithContext deletes a resource of supplied type and name
+func (c *NitroClient) DeleteResourceWithContext(ctx context.Context, resourceType string, resourceName string) error {
 	var err error
 	if resourceType == "appqoecustomresp" {
-		_, err = c.listResource(resourceType, "")
+		_, err = c.listResourceWithContext(ctx, resourceType, "")
 	} else {
-		_, err = c.listResource(resourceType, resourceName)
+		_, err = c.listResourceWithContext(ctx, resourceType, resourceName)
 	}
 	if err == nil { // resource exists
 		c.logger.Trace("DeleteResource Found resource ", "resourceType", resourceType, "resourceName", resourceName)
-		_, err = c.deleteResource(resourceType, resourceName)
+		_, err = c.deleteResourceWithContext(ctx, resourceType, resourceName)
 		if err != nil {
 			c.logger.Warn("Failed to delete resource", "resourceType", resourceType, "resourceName", resourceName, "error", err)
 			return err
@@ -400,7 +456,12 @@ func (c *NitroClient) DeleteResource(resourceType string, resourceName string) e
 // DeleteResourceWithArgs deletes a resource of supplied type and name. Args are supplied as an array of strings
 // Each array entry is formatted as "key:value"
 func (c *NitroClient) DeleteResourceWithArgs(resourceType string, resourceName string, args []string) error {
+	return c.DeleteResourceWithArgsWithContext(context.Background(), resourceType, resourceName, args)
+}
 
+// DeleteResourceWithArgsWithContext deletes a resource of supplied type and name. Args are supplied as an array of strings
+// Each array entry is formatted as "key:value"
+func (c *NitroClient) DeleteResourceWithArgsWithContext(ctx context.Context, resourceType string, resourceName string, args []string) error {
 	var err error
 	if resourceType == "snmptrap_snmpuser_binding" {
 		//Remove unwanted argument (username) for listing but keep it for delete operation
@@ -410,18 +471,18 @@ func (c *NitroClient) DeleteResourceWithArgs(resourceType string, resourceName s
 				argsWithoutUsername = append(argsWithoutUsername, args[i])
 			}
 		}
-		_, err = c.listResourceWithArgs(resourceType, resourceName, argsWithoutUsername)
+		_, err = c.listResourceWithArgsWithContext(ctx, resourceType, resourceName, argsWithoutUsername)
 	} else if resourceType == "cacheforwardproxy" {
-		_, err = c.listResource(resourceType, "")
+		_, err = c.listResourceWithContext(ctx, resourceType, "")
 	} else if resourceType == "analyticsglobal_analyticsprofile_binding" {
 		// analyticsglobal_analyticsprofile_binding has different GET implementation
-		_, err = c.listResource("analyticsglobal", "")
+		_, err = c.listResourceWithContext(ctx, "analyticsglobal", "")
 	} else {
-		_, err = c.listResourceWithArgs(resourceType, resourceName, args)
+		_, err = c.listResourceWithArgsWithContext(ctx, resourceType, resourceName, args)
 	}
 	if err == nil { // resource exists
 		c.logger.Trace("DeleteResource Found resource ", "resourceType", resourceType, "resourceName", resourceName)
-		_, err = c.deleteResourceWithArgs(resourceType, resourceName, args)
+		_, err = c.deleteResourceWithArgsWithContext(ctx, resourceType, resourceName, args)
 		if err != nil {
 			c.logger.Warn("Failed to delete resource", "resourceType", resourceType, "resourceName", resourceName, "error", err)
 			return err
@@ -434,18 +495,22 @@ func (c *NitroClient) DeleteResourceWithArgs(resourceType string, resourceName s
 
 // DeleteResourceWithArgsMap deletes a resource of supplied type and name. Args are supplied as map of key value
 func (c *NitroClient) DeleteResourceWithArgsMap(resourceType string, resourceName string, args map[string]string) error {
+	return c.DeleteResourceWithArgsMapWithContext(context.Background(), resourceType, resourceName, args)
+}
 
+// DeleteResourceWithArgsMapWithContext deletes a resource of supplied type and name. Args are supplied as map of key value
+func (c *NitroClient) DeleteResourceWithArgsMapWithContext(ctx context.Context, resourceType string, resourceName string, args map[string]string) error {
 	var err error = nil
 	var body []byte
 	if resourceType == "sslhsmkey" {
-		_, err = c.listResource(resourceType, resourceName)
+		_, err = c.listResourceWithContext(ctx, resourceType, resourceName)
 	} else {
-		_, err = c.listResourceWithArgsMap(resourceType, resourceName, args)
+		_, err = c.listResourceWithArgsMapWithContext(ctx, resourceType, resourceName, args)
 	}
 	if err == nil { // resource exists
 		c.logger.Trace("DeleteResource Found resource ", "resourceType", resourceType, "resourceName", resourceName)
 
-		body, err = c.deleteResourceWithArgsMap(resourceType, resourceName, args)
+		body, err = c.deleteResourceWithArgsMapWithContext(ctx, resourceType, resourceName, args)
 		if err != nil {
 			// Suppress error if body contains errorcode 1665 and message "Internal error while deleting HSM key"
 			if resourceType == "sslhsmkey" && strings.Contains(err.Error(), "599 Netscaler specific error") {
@@ -470,11 +535,16 @@ func (c *NitroClient) DeleteResourceWithArgsMap(resourceType string, resourceNam
 
 // BindResource binds the 'bindingResourceName' to the 'bindToResourceName'.
 func (c *NitroClient) BindResource(bindToResourceType string, bindToResourceName string, bindingResourceType string, bindingResourceName string, bindingStruct interface{}) error {
-	if !c.ResourceExists(bindToResourceType, bindToResourceName) {
+	return c.BindResourceWithContext(context.Background(), bindToResourceType, bindToResourceName, bindingResourceType, bindingResourceName, bindingStruct)
+}
+
+// BindResourceWithContext binds the 'bindingResourceName' to the 'bindToResourceName'.
+func (c *NitroClient) BindResourceWithContext(ctx context.Context, bindToResourceType string, bindToResourceName string, bindingResourceType string, bindingResourceName string, bindingStruct interface{}) error {
+	if !c.ResourceExistsWithContext(ctx, bindToResourceType, bindToResourceName) {
 		return fmt.Errorf("[ERROR] nitro-go: BindTo Resource %s of type %s does not exist", bindToResourceType, bindToResourceName)
 	}
 
-	if !c.ResourceExists(bindingResourceType, bindingResourceName) {
+	if !c.ResourceExistsWithContext(ctx, bindingResourceType, bindingResourceName) {
 		return fmt.Errorf("[ERROR] nitro-go: Binding Resource %s of type %s does not exist", bindingResourceType, bindingResourceName)
 	}
 	bindingName := bindToResourceType + "_" + bindingResourceType + "_binding"
@@ -483,7 +553,7 @@ func (c *NitroClient) BindResource(bindToResourceType string, bindToResourceName
 
 	resourceJSON, _ := JSONMarshal(nsBinding)
 
-	body, err := c.createResource(bindingName, resourceJSON)
+	body, err := c.createResourceWithContext(ctx, bindingName, resourceJSON)
 	if err != nil {
 		return fmt.Errorf("[ERROR] nitro-go: Failed to bind resource %s to resource %s, err=%s", bindToResourceName, bindingResourceName, err)
 	}
@@ -493,18 +563,23 @@ func (c *NitroClient) BindResource(bindToResourceType string, bindToResourceName
 
 // UnbindResource unbinds 'boundResourceName' from 'boundToResource'
 func (c *NitroClient) UnbindResource(boundToResourceType string, boundToResourceName string, boundResourceType string, boundResourceName string, bindingFilterName string) error {
+	return c.UnbindResourceWithContext(context.Background(), boundToResourceType, boundToResourceName, boundResourceType, boundResourceName, bindingFilterName)
+}
 
-	if !c.ResourceExists(boundToResourceType, boundToResourceName) {
+// UnbindResourceWithContext unbinds 'boundResourceName' from 'boundToResource'
+func (c *NitroClient) UnbindResourceWithContext(ctx context.Context, boundToResourceType string, boundToResourceName string, boundResourceType string, boundResourceName string, bindingFilterName string) error {
+
+	if !c.ResourceExistsWithContext(ctx, boundToResourceType, boundToResourceName) {
 		c.logger.Info(" Unbind: BoundTo Resource  does not exist", "boundToResourceType", boundToResourceType, "boundToResourceName", boundToResourceName)
 		return nil
 	}
 
-	if !c.ResourceExists(boundResourceType, boundResourceName) {
+	if !c.ResourceExistsWithContext(ctx, boundResourceType, boundResourceName) {
 		c.logger.Info(" Unbind: Bound Resource  does not exist", "boundResourceType", boundResourceType, "boundResourceName", boundResourceName)
 		return nil
 	}
 
-	_, err := c.unbindResource(boundToResourceType, boundToResourceName, boundResourceType, boundResourceName, bindingFilterName)
+	_, err := c.unbindResourceWithContext(ctx, boundToResourceType, boundToResourceName, boundResourceType, boundResourceName, bindingFilterName)
 	if err != nil {
 		return fmt.Errorf("[ERROR] Failed to unbind  %s:%s from %s:%s, err=%s", boundResourceType, boundResourceName, boundToResourceType, boundToResourceName, err)
 	}
@@ -514,7 +589,12 @@ func (c *NitroClient) UnbindResource(boundToResourceType string, boundToResource
 
 // ResourceExists returns true if supplied resource name and type exists
 func (c *NitroClient) ResourceExists(resourceType string, resourceName string) bool {
-	_, err := c.listResource(resourceType, resourceName)
+	return c.ResourceExistsWithContext(context.Background(), resourceType, resourceName)
+}
+
+// ResourceExistsWithContext returns true if supplied resource name and type exists
+func (c *NitroClient) ResourceExistsWithContext(ctx context.Context, resourceType string, resourceName string) bool {
+	_, err := c.listResourceWithContext(ctx, resourceType, resourceName)
 	if err != nil {
 		c.logger.Debug("ResourceExists: No resource found", "resourceType", resourceType, "resourceName", resourceName)
 		return false
@@ -525,8 +605,13 @@ func (c *NitroClient) ResourceExists(resourceType string, resourceName string) b
 
 // FindResourceArray returns the config of the supplied resource name and type if it exists. Use when the resource to be returned is an array
 func (c *NitroClient) FindResourceArray(resourceType string, resourceName string) ([]map[string]interface{}, error) {
+	return c.FindResourceArrayWithContext(context.Background(), resourceType, resourceName)
+}
+
+// FindResourceArrayWithContext returns the config of the supplied resource name and type if it exists. Use when the resource to be returned is an array
+func (c *NitroClient) FindResourceArrayWithContext(ctx context.Context, resourceType string, resourceName string) ([]map[string]interface{}, error) {
 	var data map[string]interface{}
-	result, err := c.listResource(resourceType, resourceName)
+	result, err := c.listResourceWithContext(ctx, resourceType, resourceName)
 	if err != nil {
 		c.logger.Warn("FindResourceArray: No resources found", "resourceType", resourceType, "resourceName", resourceName)
 		return nil, fmt.Errorf("[INFO] nitro-go: FindResourceArray: No resource %s of type %s found", resourceName, resourceType)
@@ -550,8 +635,13 @@ func (c *NitroClient) FindResourceArray(resourceType string, resourceName string
 
 // FindFilteredResourceArray returns the config of the supplied resource type, filtered with given filter
 func (c *NitroClient) FindFilteredResourceArray(resourceType string, filter map[string]string) ([]map[string]interface{}, error) {
+	return c.FindFilteredResourceArrayWithContext(context.Background(), resourceType, filter)
+}
+
+// FindFilteredResourceArrayWithContext returns the config of the supplied resource type, filtered with given filter
+func (c *NitroClient) FindFilteredResourceArrayWithContext(ctx context.Context, resourceType string, filter map[string]string) ([]map[string]interface{}, error) {
 	var data map[string]interface{}
-	result, err := c.listFilteredResource(resourceType, filter)
+	result, err := c.listFilteredResourceWithContext(ctx, resourceType, filter)
 	if err != nil {
 		c.logger.Warn("FindFilteredResourceArray: No resource found matching filter", "resourceType", resourceType, "filter", filter)
 		return nil, fmt.Errorf("[INFO] nitro-go: FindFilteredResourceArray: No resource of type %s found matching filter %s", resourceType, filter)
@@ -575,8 +665,13 @@ func (c *NitroClient) FindFilteredResourceArray(resourceType string, filter map[
 
 // FindResource returns the config of the supplied resource name and type if it exists
 func (c *NitroClient) FindResource(resourceType string, resourceName string) (map[string]interface{}, error) {
+	return c.FindResourceWithContext(context.Background(), resourceType, resourceName)
+}
+
+// FindResourceWithContext returns the config of the supplied resource name and type if it exists
+func (c *NitroClient) FindResourceWithContext(ctx context.Context, resourceType string, resourceName string) (map[string]interface{}, error) {
 	var data map[string]interface{}
-	result, err := c.listResource(resourceType, resourceName)
+	result, err := c.listResourceWithContext(ctx, resourceType, resourceName)
 	if err != nil {
 		c.logger.Warn("FindResource: No resource found", "resourceType", resourceType, "resourceName", resourceName)
 		return nil, fmt.Errorf("[INFO] nitro-go: FindResource: No resource %s of type %s found", resourceName, resourceType)
@@ -611,6 +706,11 @@ func (c *NitroClient) FindResource(resourceType string, resourceName string) (ma
 // Multiple elements array means NITRO returned multiple results
 // It is left to the user to determine the sanity of the return value
 func (c *NitroClient) FindResourceArrayWithParams(findParams FindParams) ([]map[string]interface{}, error) {
+	return c.FindResourceArrayWithParamsWithContext(context.Background(), findParams)
+}
+
+// FindResourceArrayWithParamsWithContext is meant to be a generic and extendable function to implement all the possible GET methods NITRO will allow.
+func (c *NitroClient) FindResourceArrayWithParamsWithContext(ctx context.Context, findParams FindParams) ([]map[string]interface{}, error) {
 
 	// Construct the url
 	var urlBuilder strings.Builder
@@ -629,7 +729,7 @@ func (c *NitroClient) FindResourceArrayWithParams(findParams FindParams) ([]map[
 	url := urlBuilder.String()
 
 	c.logger.Trace("FindResourceArrayWithParams: url is", "url", url)
-	result, httpErr := c.doHTTPRequest("GET", url, bytes.NewBuffer([]byte{}), readResponseHandler)
+	result, httpErr := c.doHTTPRequestWithContext(ctx, "GET", url, bytes.NewBuffer([]byte{}), readResponseHandler)
 	c.logger.Trace("FindResourceArrayWithParams: HTTP GET result", "result", string(result), "error", httpErr)
 
 	// Ignore 404.
@@ -718,8 +818,13 @@ func (c *NitroClient) FindResourceArrayWithParams(findParams FindParams) ([]map[
 
 // FindAllResources finds all config objects of the supplied resource type and returns them in an array
 func (c *NitroClient) FindAllResources(resourceType string) ([]map[string]interface{}, error) {
+	return c.FindAllResourcesWithContext(context.Background(), resourceType)
+}
+
+// FindAllResourcesWithContext finds all config objects of the supplied resource type and returns them in an array
+func (c *NitroClient) FindAllResourcesWithContext(ctx context.Context, resourceType string) ([]map[string]interface{}, error) {
 	var data map[string]interface{}
-	result, err := c.listResource(resourceType, "")
+	result, err := c.listResourceWithContext(ctx, resourceType, "")
 	if err != nil {
 		c.logger.Trace(" FindAllResources: No objects found", "resourceType", resourceType)
 		return make([]map[string]interface{}, 0, 0), nil
@@ -749,7 +854,12 @@ func (c *NitroClient) FindAllResources(resourceType string) ([]map[string]interf
 
 // ResourceBindingExists returns true if the supplied binding exists
 func (c *NitroClient) ResourceBindingExists(resourceType string, resourceName string, boundResourceType string, boundResourceFilterName string, boundResourceFilterValue string) bool {
-	result, err := c.listBoundResources(resourceName, resourceType, boundResourceType, boundResourceFilterName, boundResourceFilterValue)
+	return c.ResourceBindingExistsWithContext(context.Background(), resourceType, resourceName, boundResourceType, boundResourceFilterName, boundResourceFilterValue)
+}
+
+// ResourceBindingExistsWithContext returns true if the supplied binding exists
+func (c *NitroClient) ResourceBindingExistsWithContext(ctx context.Context, resourceType string, resourceName string, boundResourceType string, boundResourceFilterName string, boundResourceFilterValue string) bool {
+	result, err := c.listBoundResourcesWithContext(ctx, resourceName, resourceType, boundResourceType, boundResourceFilterName, boundResourceFilterValue)
 	if err != nil {
 		c.logger.Trace("ResourceBindingExists: No bound resource to found", "resourceType", resourceType, "name", resourceName, "boundResourceType", boundResourceType, "boundResourceFilterValue", boundResourceFilterValue)
 		return false
@@ -772,7 +882,12 @@ func (c *NitroClient) ResourceBindingExists(resourceType string, resourceName st
 
 // FindBoundResource finds a bound resource if it exists
 func (c *NitroClient) FindBoundResource(resourceType string, resourceName string, boundResourceType string, boundResourceFilterName string, boundResourceFilterValue string) (map[string]interface{}, error) {
-	result, err := c.listBoundResources(resourceName, resourceType, boundResourceType, boundResourceFilterName, boundResourceFilterValue)
+	return c.FindBoundResourceWithContext(context.Background(), resourceType, resourceName, boundResourceType, boundResourceFilterName, boundResourceFilterValue)
+}
+
+// FindBoundResourceWithContext finds a bound resource if it exists
+func (c *NitroClient) FindBoundResourceWithContext(ctx context.Context, resourceType string, resourceName string, boundResourceType string, boundResourceFilterName string, boundResourceFilterValue string) (map[string]interface{}, error) {
+	result, err := c.listBoundResourcesWithContext(ctx, resourceName, resourceType, boundResourceType, boundResourceFilterName, boundResourceFilterValue)
 	if err != nil {
 		c.logger.Info(" FindBoundResource: No binding found", "resourceType", resourceType, "resourceName", "resourceName", resourceName, "boundResourceType", boundResourceType, "boundResourceFilterValue", boundResourceFilterValue)
 		return nil, fmt.Errorf("[INFO] nitro-go: No %s %s to %s %s binding found, err=%s", resourceType, resourceName, boundResourceType, boundResourceFilterValue, err)
@@ -796,7 +911,12 @@ func (c *NitroClient) FindBoundResource(resourceType string, resourceName string
 
 // FindAllBoundResources returns an array of bound config objects of the type specified that are bound to the resource specified
 func (c *NitroClient) FindAllBoundResources(resourceType string, resourceName string, boundResourceType string) ([]map[string]interface{}, error) {
-	result, err := c.listBoundResources(resourceName, resourceType, boundResourceType, "", "")
+	return c.FindAllBoundResourcesWithContext(context.Background(), resourceType, resourceName, boundResourceType)
+}
+
+// FindAllBoundResourcesWithContext returns an array of bound config objects of the type specified that are bound to the resource specified
+func (c *NitroClient) FindAllBoundResourcesWithContext(ctx context.Context, resourceType string, resourceName string, boundResourceType string) ([]map[string]interface{}, error) {
+	result, err := c.listBoundResourcesWithContext(ctx, resourceName, resourceType, boundResourceType, "", "")
 	if err != nil {
 		c.logger.Info("FindAllBoundResources: No binding found", "resourceType", resourceType, "resourceName", "resourceName", resourceName, "boundResourceType", boundResourceType)
 		return nil, fmt.Errorf("[ERROR] nitro-go: No %s %s to %s binding found, err=%s", resourceType, resourceName, boundResourceType, err)
@@ -824,6 +944,12 @@ func (c *NitroClient) FindAllBoundResources(resourceType string, resourceName st
 // EnableFeatures enables the provided list of features. Depending on the licensing of the NetScaler, not all supplied features may actually
 // enabled
 func (c *NitroClient) EnableFeatures(featureNames []string) error {
+	return c.EnableFeaturesWithContext(context.Background(), featureNames)
+}
+
+// EnableFeaturesWithContext enables the provided list of features. Depending on the licensing of the NetScaler, not all supplied features may actually
+// enabled
+func (c *NitroClient) EnableFeaturesWithContext(ctx context.Context, featureNames []string) error {
 	/* construct this:
 	{
 	        "nsfeature":
@@ -842,7 +968,7 @@ func (c *NitroClient) EnableFeatures(featureNames []string) error {
 		return fmt.Errorf("[ERROR] nitro-go: Failed to marshal features to JSON")
 	}
 
-	_, err = c.enableFeatures(featureJSON)
+	_, err = c.enableFeaturesWithContext(ctx, featureJSON)
 	if err != nil {
 		return fmt.Errorf("[ERROR] Failed to enable feature %v", err)
 	}
@@ -850,6 +976,10 @@ func (c *NitroClient) EnableFeatures(featureNames []string) error {
 }
 
 func (c *NitroClient) DisableFeatures(featureNames []string) error {
+	return c.DisableFeaturesWithContext(context.Background(), featureNames)
+}
+
+func (c *NitroClient) DisableFeaturesWithContext(ctx context.Context, featureNames []string) error {
 	/* construct this:
 	{
 	        "nsfeature":
@@ -868,7 +998,7 @@ func (c *NitroClient) DisableFeatures(featureNames []string) error {
 		return fmt.Errorf("[ERROR] nitro-go: Failed to marshal features to JSON")
 	}
 
-	_, err = c.disableFeatures(featureJSON)
+	_, err = c.disableFeaturesWithContext(ctx, featureJSON)
 	if err != nil {
 		return fmt.Errorf("[ERROR] nitro-go: Failed to disable feature %v", err)
 	}
@@ -877,8 +1007,13 @@ func (c *NitroClient) DisableFeatures(featureNames []string) error {
 
 // ListEnabledFeatures returns a string array of the list of features enabled on the NetScaler appliance
 func (c *NitroClient) ListEnabledFeatures() ([]string, error) {
+	return c.ListEnabledFeaturesWithContext(context.Background())
+}
 
-	bytes, err := c.listEnabledFeatures()
+// ListEnabledFeaturesWithContext returns a string array of the list of features enabled on the NetScaler appliance
+func (c *NitroClient) ListEnabledFeaturesWithContext(ctx context.Context) ([]string, error) {
+
+	bytes, err := c.listEnabledFeaturesWithContext(ctx)
 	if err != nil {
 		return []string{}, fmt.Errorf("[ERROR] nitro-go: Failed to list features %v", err)
 	}
@@ -909,6 +1044,11 @@ func (c *NitroClient) ListEnabledFeatures() ([]string, error) {
 
 // EnableModes enables the provided list of Citrix ADC modes.
 func (c *NitroClient) EnableModes(modeNames []string) error {
+	return c.EnableModesWithContext(context.Background(), modeNames)
+}
+
+// EnableModesWithContext enables the provided list of Citrix ADC modes.
+func (c *NitroClient) EnableModesWithContext(ctx context.Context, modeNames []string) error {
 	/* construct this:
 	{
 	        "nsmode":
@@ -927,7 +1067,7 @@ func (c *NitroClient) EnableModes(modeNames []string) error {
 		return fmt.Errorf("[ERROR] nitro-go: Failed to marshal modes to JSON")
 	}
 
-	_, err = c.enableModes(modeJSON)
+	_, err = c.enableModesWithContext(ctx, modeJSON)
 	if err != nil {
 		return fmt.Errorf("[ERROR] nitro-go: Failed to enable mode %v", err)
 	}
@@ -936,8 +1076,13 @@ func (c *NitroClient) EnableModes(modeNames []string) error {
 
 // ListEnabledModes returns a string array of the list of modes enabled on the Citrix ADC appliance
 func (c *NitroClient) ListEnabledModes() ([]string, error) {
+	return c.ListEnabledModesWithContext(context.Background())
+}
 
-	bytes, err := c.listEnabledModes()
+// ListEnabledModesWithContext returns a string array of the list of modes enabled on the Citrix ADC appliance
+func (c *NitroClient) ListEnabledModesWithContext(ctx context.Context) ([]string, error) {
+
+	bytes, err := c.listEnabledModesWithContext(ctx)
 	if err != nil {
 		return []string{}, fmt.Errorf("[ERROR] nitro-go: Failed to list modes %v", err)
 	}
@@ -968,6 +1113,11 @@ func (c *NitroClient) ListEnabledModes() ([]string, error) {
 
 // SaveConfig persists the config on the NetScaler to the NetScaler's persistent storage. This could take a few seconds
 func (c *NitroClient) SaveConfig() error {
+	return c.SaveConfigWithContext(context.Background())
+}
+
+// SaveConfigWithContext persists the config on the NetScaler to the NetScaler's persistent storage. This could take a few seconds
+func (c *NitroClient) SaveConfigWithContext(ctx context.Context) error {
 	/* construct this:
 	{
 	        "nsconfig": {}
@@ -983,7 +1133,7 @@ func (c *NitroClient) SaveConfig() error {
 	}
 	c.logger.Debug("saveJSON", "json", string(saveJSON))
 
-	err = c.saveConfig(saveJSON)
+	err = c.saveConfigWithContext(ctx, saveJSON)
 	if err != nil {
 		return fmt.Errorf("[ERROR] nitro-go: Failed to save config %v", err)
 	}
@@ -992,6 +1142,11 @@ func (c *NitroClient) SaveConfig() error {
 
 // ClearConfig deletes the config on the NetScaler
 func (c *NitroClient) ClearConfig() error {
+	return c.ClearConfigWithContext(context.Background())
+}
+
+// ClearConfigWithContext deletes the config on the NetScaler
+func (c *NitroClient) ClearConfigWithContext(ctx context.Context) error {
 	/* construct this:
 	{
 	    "nsconfig": {"level": "basic"}
@@ -1009,7 +1164,7 @@ func (c *NitroClient) ClearConfig() error {
 	}
 	c.logger.Trace("clearJSON is ", "text", string(clearJSON))
 
-	err = c.clearConfig(clearJSON)
+	err = c.clearConfigWithContext(ctx, clearJSON)
 	if err != nil {
 		return fmt.Errorf("[ERROR] nitro-go: Failed to clear config %v", err)
 	}

--- a/service/netscaler_resource.go
+++ b/service/netscaler_resource.go
@@ -18,6 +18,7 @@ package service
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -150,7 +151,11 @@ func readResponseHandler(resp *http.Response, logger hclog.Logger) ([]byte, erro
 }
 
 func (c *NitroClient) createHTTPRequest(method string, urlstr string, buff *bytes.Buffer) (*http.Request, error) {
-	req, err := http.NewRequest(method, urlstr, buff)
+	return c.createHTTPRequestWithContext(context.Background(), method, urlstr, buff)
+}
+
+func (c *NitroClient) createHTTPRequestWithContext(ctx context.Context, method string, urlstr string, buff *bytes.Buffer) (*http.Request, error) {
+	req, err := http.NewRequestWithContext(ctx, method, urlstr, buff)
 	if err != nil {
 		return nil, err
 	}
@@ -217,7 +222,14 @@ func maskHeaders(headers http.Header) http.Header {
 }
 
 func (c *NitroClient) doHTTPRequest(method string, urlstr string, bytes *bytes.Buffer, respHandler responseHandlerFunc) ([]byte, error) {
-	req, err := c.createHTTPRequest(method, urlstr, bytes)
+	return c.doHTTPRequestWithContext(context.Background(), method, urlstr, bytes, respHandler)
+}
+
+func (c *NitroClient) doHTTPRequestWithContext(ctx context.Context, method string, urlstr string, bytes *bytes.Buffer, respHandler responseHandlerFunc) ([]byte, error) {
+	req, err := c.createHTTPRequestWithContext(ctx, method, urlstr, bytes)
+	if err != nil {
+		return []byte{}, err
+	}
 
 	maskedHeaders := maskHeaders(req.Header)
 	c.logger.Trace("doHTTPRequest HTTP method", "method", method, "url", urlstr, "headers", maskedHeaders)
@@ -249,6 +261,10 @@ func (c *NitroClient) doHTTPRequest(method string, urlstr string, bytes *bytes.B
 }
 
 func (c *NitroClient) createResource(resourceType string, resourceJSON []byte) ([]byte, error) {
+	return c.createResourceWithContext(context.Background(), resourceType, resourceJSON)
+}
+
+func (c *NitroClient) createResourceWithContext(ctx context.Context, resourceType string, resourceJSON []byte) ([]byte, error) {
 	c.logger.Trace("Creating ", "resourceType", resourceType)
 
 	url := c.url + resourceType
@@ -258,21 +274,29 @@ func (c *NitroClient) createResource(resourceType string, resourceJSON []byte) (
 	}
 	c.logger.Trace("createResource", "url", url)
 
-	return c.doHTTPRequest("POST", url, bytes.NewBuffer(resourceJSON), createResponseHandler)
+	return c.doHTTPRequestWithContext(ctx, "POST", url, bytes.NewBuffer(resourceJSON), createResponseHandler)
 
 }
 
 func (c *NitroClient) applyResource(resourceType string, resourceJSON []byte) ([]byte, error) {
+	return c.applyResourceWithContext(context.Background(), resourceType, resourceJSON)
+}
+
+func (c *NitroClient) applyResourceWithContext(ctx context.Context, resourceType string, resourceJSON []byte) ([]byte, error) {
 	c.logger.Trace("Applying", "resourceType", resourceType)
 
 	url := c.url + resourceType + "?action=apply"
 	c.logger.Trace("url is ", "url", url)
 
-	return c.doHTTPRequest("POST", url, bytes.NewBuffer(resourceJSON), createResponseHandler)
+	return c.doHTTPRequestWithContext(ctx, "POST", url, bytes.NewBuffer(resourceJSON), createResponseHandler)
 
 }
 
 func (c *NitroClient) actOnResource(resourceType string, resourceJSON []byte, action string) ([]byte, error) {
+	return c.actOnResourceWithContext(context.Background(), resourceType, resourceJSON, action)
+}
+
+func (c *NitroClient) actOnResourceWithContext(ctx context.Context, resourceType string, resourceJSON []byte, action string) ([]byte, error) {
 	c.logger.Trace("acting on resource", "resourceType", resourceType)
 
 	var url string
@@ -283,43 +307,59 @@ func (c *NitroClient) actOnResource(resourceType string, resourceJSON []byte, ac
 	}
 	c.logger.Trace("actOnResource ", "url", url)
 
-	return c.doHTTPRequest("POST", url, bytes.NewBuffer(resourceJSON), createResponseHandler)
+	return c.doHTTPRequestWithContext(ctx, "POST", url, bytes.NewBuffer(resourceJSON), createResponseHandler)
 
 }
 
 func (c *NitroClient) changeResource(resourceType string, resourceName string, resourceJSON []byte) ([]byte, error) {
+	return c.changeResourceWithContext(context.Background(), resourceType, resourceName, resourceJSON)
+}
+
+func (c *NitroClient) changeResourceWithContext(ctx context.Context, resourceType string, resourceName string, resourceJSON []byte) ([]byte, error) {
 	c.logger.Trace("changing resource", "resourceType", resourceType)
 
 	resourceNameEscaped := neturl.QueryEscape(neturl.QueryEscape(resourceName))
 	url := c.url + resourceType + "/" + resourceNameEscaped + "?action=update"
 	c.logger.Trace("changeResource", "url", url)
 
-	return c.doHTTPRequest("POST", url, bytes.NewBuffer(resourceJSON), createResponseHandler)
+	return c.doHTTPRequestWithContext(ctx, "POST", url, bytes.NewBuffer(resourceJSON), createResponseHandler)
 
 }
 
 func (c *NitroClient) updateResource(resourceType string, resourceName string, resourceJSON []byte) ([]byte, error) {
+	return c.updateResourceWithContext(context.Background(), resourceType, resourceName, resourceJSON)
+}
+
+func (c *NitroClient) updateResourceWithContext(ctx context.Context, resourceType string, resourceName string, resourceJSON []byte) ([]byte, error) {
 	c.logger.Trace("Updating resource ", "resourceType", resourceType)
 
 	resourceNameEscaped := neturl.QueryEscape(neturl.QueryEscape(resourceName))
 	url := c.url + resourceType + "/" + resourceNameEscaped
 	c.logger.Trace("updateResource ", "url", url)
 
-	return c.doHTTPRequest("PUT", url, bytes.NewBuffer(resourceJSON), createResponseHandler)
+	return c.doHTTPRequestWithContext(ctx, "PUT", url, bytes.NewBuffer(resourceJSON), createResponseHandler)
 
 }
 
 func (c *NitroClient) updateUnnamedResource(resourceType string, resourceJSON []byte) ([]byte, error) {
+	return c.updateUnnamedResourceWithContext(context.Background(), resourceType, resourceJSON)
+}
+
+func (c *NitroClient) updateUnnamedResourceWithContext(ctx context.Context, resourceType string, resourceJSON []byte) ([]byte, error) {
 	c.logger.Trace("Updating unnamed resource", "resourceType", resourceType)
 
 	url := c.url + resourceType
 	c.logger.Trace("updateUnnamedResource", "url", url)
 
-	return c.doHTTPRequest("PUT", url, bytes.NewBuffer(resourceJSON), createResponseHandler)
+	return c.doHTTPRequestWithContext(ctx, "PUT", url, bytes.NewBuffer(resourceJSON), createResponseHandler)
 
 }
 
 func (c *NitroClient) deleteResource(resourceType string, resourceName string) ([]byte, error) {
+	return c.deleteResourceWithContext(context.Background(), resourceType, resourceName)
+}
+
+func (c *NitroClient) deleteResourceWithContext(ctx context.Context, resourceType string, resourceName string) ([]byte, error) {
 	c.logger.Trace("Deleting resource", "resourceType", resourceType)
 	var url string
 	if resourceName != "" {
@@ -330,11 +370,15 @@ func (c *NitroClient) deleteResource(resourceType string, resourceName string) (
 	}
 	c.logger.Trace("deleteResource", "url", url)
 
-	return c.doHTTPRequest("DELETE", url, bytes.NewBuffer([]byte{}), deleteResponseHandler)
+	return c.doHTTPRequestWithContext(ctx, "DELETE", url, bytes.NewBuffer([]byte{}), deleteResponseHandler)
 
 }
 
 func (c *NitroClient) deleteResourceWithArgs(resourceType string, resourceName string, args []string) ([]byte, error) {
+	return c.deleteResourceWithArgsWithContext(context.Background(), resourceType, resourceName, args)
+}
+
+func (c *NitroClient) deleteResourceWithArgsWithContext(ctx context.Context, resourceType string, resourceName string, args []string) ([]byte, error) {
 	c.logger.Trace("Deleting resource with args", "resourceType", resourceType, "args ", args)
 	var url string
 	if resourceName != "" {
@@ -346,33 +390,45 @@ func (c *NitroClient) deleteResourceWithArgs(resourceType string, resourceName s
 	url = url + strings.Join(args, ",")
 	c.logger.Trace("deleteResourceWithArgs ", "url", url)
 
-	return c.doHTTPRequest("DELETE", url, bytes.NewBuffer([]byte{}), deleteResponseHandler)
+	return c.doHTTPRequestWithContext(ctx, "DELETE", url, bytes.NewBuffer([]byte{}), deleteResponseHandler)
 
 }
 
 func (c *NitroClient) deleteResourceWithArgsMap(resourceType string, resourceName string, argsMap map[string]string) ([]byte, error) {
+	return c.deleteResourceWithArgsMapWithContext(context.Background(), resourceType, resourceName, argsMap)
+}
+
+func (c *NitroClient) deleteResourceWithArgsMapWithContext(ctx context.Context, resourceType string, resourceName string, argsMap map[string]string) ([]byte, error) {
 	args := make([]string, len(argsMap))
 	i := 0
 	for key, value := range argsMap {
 		args[i] = fmt.Sprintf("%s:%s", key, value)
 		i++
 	}
-	return c.deleteResourceWithArgs(resourceType, resourceName, args)
+	return c.deleteResourceWithArgsWithContext(ctx, resourceType, resourceName, args)
 
 }
 
 func (c *NitroClient) unbindResource(resourceType string, resourceName string, boundResourceType string, boundResource string, bindingFilterName string) ([]byte, error) {
+	return c.unbindResourceWithContext(context.Background(), resourceType, resourceName, boundResourceType, boundResource, bindingFilterName)
+}
+
+func (c *NitroClient) unbindResourceWithContext(ctx context.Context, resourceType string, resourceName string, boundResourceType string, boundResource string, bindingFilterName string) ([]byte, error) {
 	c.logger.Trace("Unbinding resource", "resourceType", resourceType, "resourceName", resourceName)
 	bindingName := resourceType + "_" + boundResourceType + "_binding"
 	resourceNameEscaped := neturl.QueryEscape(neturl.QueryEscape(resourceName))
 
 	url := c.url + "/" + bindingName + "/" + resourceNameEscaped + "?args=" + bindingFilterName + ":" + boundResource
 
-	return c.doHTTPRequest("DELETE", url, bytes.NewBuffer([]byte{}), deleteResponseHandler)
+	return c.doHTTPRequestWithContext(ctx, "DELETE", url, bytes.NewBuffer([]byte{}), deleteResponseHandler)
 
 }
 
 func (c *NitroClient) listBoundResources(resourceName string, resourceType string, boundResourceType string, boundResourceFilterName string, boundResourceFilterValue string) ([]byte, error) {
+	return c.listBoundResourcesWithContext(context.Background(), resourceName, resourceType, boundResourceType, boundResourceFilterName, boundResourceFilterValue)
+}
+
+func (c *NitroClient) listBoundResourcesWithContext(ctx context.Context, resourceName string, resourceType string, boundResourceType string, boundResourceFilterName string, boundResourceFilterValue string) ([]byte, error) {
 	c.logger.Trace("listing bound resources of type ", "resourceType", resourceType, "resourceName", resourceName)
 	var url string
 	resourceNameEscaped := neturl.QueryEscape(neturl.QueryEscape(resourceName))
@@ -382,11 +438,15 @@ func (c *NitroClient) listBoundResources(resourceName string, resourceType strin
 		url = c.url + fmt.Sprintf("%s_%s_binding/%s?filter=%s:%s", resourceType, boundResourceType, resourceNameEscaped, boundResourceFilterName, boundResourceFilterValue)
 	}
 
-	return c.doHTTPRequest("GET", url, bytes.NewBuffer([]byte{}), readResponseHandler)
+	return c.doHTTPRequestWithContext(ctx, "GET", url, bytes.NewBuffer([]byte{}), readResponseHandler)
 
 }
 
 func (c *NitroClient) listFilteredResource(resourceType string, filter map[string]string) ([]byte, error) {
+	return c.listFilteredResourceWithContext(context.Background(), resourceType, filter)
+}
+
+func (c *NitroClient) listFilteredResourceWithContext(ctx context.Context, resourceType string, filter map[string]string) ([]byte, error) {
 	c.logger.Trace("listing filtered resource of type ", "resourceType", resourceType, "filter: ", filter)
 
 	var filter_strings []string
@@ -398,11 +458,15 @@ func (c *NitroClient) listFilteredResource(resourceType string, filter map[strin
 
 	url := c.url + fmt.Sprintf("%s?filter=%s", resourceType, filter_string)
 
-	return c.doHTTPRequest("GET", url, bytes.NewBuffer([]byte{}), readResponseHandler)
+	return c.doHTTPRequestWithContext(ctx, "GET", url, bytes.NewBuffer([]byte{}), readResponseHandler)
 
 }
 
 func (c *NitroClient) listResource(resourceType string, resourceName string) ([]byte, error) {
+	return c.listResourceWithContext(context.Background(), resourceType, resourceName)
+}
+
+func (c *NitroClient) listResourceWithContext(ctx context.Context, resourceType string, resourceName string) ([]byte, error) {
 	c.logger.Trace("listing resource of type ", "resourceType", resourceType, "name", resourceName)
 	url := c.url + resourceType
 
@@ -412,11 +476,15 @@ func (c *NitroClient) listResource(resourceType string, resourceName string) ([]
 	}
 	c.logger.Trace("listResource", "url", url)
 
-	return c.doHTTPRequest("GET", url, bytes.NewBuffer([]byte{}), readResponseHandler)
+	return c.doHTTPRequestWithContext(ctx, "GET", url, bytes.NewBuffer([]byte{}), readResponseHandler)
 
 }
 
 func (c *NitroClient) listResourceWithArgs(resourceType string, resourceName string, args []string) ([]byte, error) {
+	return c.listResourceWithArgsWithContext(context.Background(), resourceType, resourceName, args)
+}
+
+func (c *NitroClient) listResourceWithArgsWithContext(ctx context.Context, resourceType string, resourceName string, args []string) ([]byte, error) {
 	c.logger.Trace("listing resource with args ", "resourceType", resourceType, "name", resourceName, "args", args)
 	var url string
 
@@ -430,86 +498,122 @@ func (c *NitroClient) listResourceWithArgs(resourceType string, resourceName str
 	url2 := url + "?args=" + strArgs
 	c.logger.Trace("listResourceWithArgs", "url", url)
 
-	data, err := c.doHTTPRequest("GET", url2, bytes.NewBuffer([]byte{}), readResponseHandler)
+	data, err := c.doHTTPRequestWithContext(ctx, "GET", url2, bytes.NewBuffer([]byte{}), readResponseHandler)
 	if err != nil {
 		c.logger.Trace("listResourceWithArgs: error listing with args, trying filter", "error", err)
 		url2 = url + "?filter=" + strArgs
 		c.logger.Trace("listResourceWithArgs", "url2", url2)
-		return c.doHTTPRequest("GET", url2, bytes.NewBuffer([]byte{}), readResponseHandler)
+		return c.doHTTPRequestWithContext(ctx, "GET", url2, bytes.NewBuffer([]byte{}), readResponseHandler)
 	}
 	return data, err
 
 }
 
 func (c *NitroClient) listResourceWithArgsMap(resourceType string, resourceName string, argsMap map[string]string) ([]byte, error) {
+	return c.listResourceWithArgsMapWithContext(context.Background(), resourceType, resourceName, argsMap)
+}
+
+func (c *NitroClient) listResourceWithArgsMapWithContext(ctx context.Context, resourceType string, resourceName string, argsMap map[string]string) ([]byte, error) {
 	args := make([]string, len(argsMap))
 	i := 0
 	for key, value := range argsMap {
 		args[i] = fmt.Sprintf("%s:%s", key, value)
 		i++
 	}
-	return c.listResourceWithArgs(resourceType, resourceName, args)
+	return c.listResourceWithArgsWithContext(ctx, resourceType, resourceName, args)
 
 }
 
 func (c *NitroClient) enableFeatures(featureJSON []byte) ([]byte, error) {
+	return c.enableFeaturesWithContext(context.Background(), featureJSON)
+}
+
+func (c *NitroClient) enableFeaturesWithContext(ctx context.Context, featureJSON []byte) ([]byte, error) {
 	c.logger.Trace("Enabling features")
 	url := c.url + "nsfeature?action=enable"
 
-	return c.doHTTPRequest("POST", url, bytes.NewBuffer(featureJSON), createResponseHandler)
+	return c.doHTTPRequestWithContext(ctx, "POST", url, bytes.NewBuffer(featureJSON), createResponseHandler)
 
 }
 
 func (c *NitroClient) disableFeatures(featureJSON []byte) ([]byte, error) {
+	return c.disableFeaturesWithContext(context.Background(), featureJSON)
+}
+
+func (c *NitroClient) disableFeaturesWithContext(ctx context.Context, featureJSON []byte) ([]byte, error) {
 	c.logger.Trace("Disabling features")
 	url := c.url + "nsfeature?action=disable"
 
-	return c.doHTTPRequest("POST", url, bytes.NewBuffer(featureJSON), createResponseHandler)
+	return c.doHTTPRequestWithContext(ctx, "POST", url, bytes.NewBuffer(featureJSON), createResponseHandler)
 
 }
 
 func (c *NitroClient) listEnabledFeatures() ([]byte, error) {
+	return c.listEnabledFeaturesWithContext(context.Background())
+}
+
+func (c *NitroClient) listEnabledFeaturesWithContext(ctx context.Context) ([]byte, error) {
 	c.logger.Trace("listing features")
 	url := c.url + "nsfeature"
 
-	return c.doHTTPRequest("GET", url, bytes.NewBuffer([]byte{}), readResponseHandler)
+	return c.doHTTPRequestWithContext(ctx, "GET", url, bytes.NewBuffer([]byte{}), readResponseHandler)
 
 }
 
 func (c *NitroClient) enableModes(modeJSON []byte) ([]byte, error) {
+	return c.enableModesWithContext(context.Background(), modeJSON)
+}
+
+func (c *NitroClient) enableModesWithContext(ctx context.Context, modeJSON []byte) ([]byte, error) {
 	c.logger.Trace("Enabling modes")
 	url := c.url + "nsmode?action=enable"
 
-	return c.doHTTPRequest("POST", url, bytes.NewBuffer(modeJSON), createResponseHandler)
+	return c.doHTTPRequestWithContext(ctx, "POST", url, bytes.NewBuffer(modeJSON), createResponseHandler)
 
 }
 
 func (c *NitroClient) listEnabledModes() ([]byte, error) {
+	return c.listEnabledModesWithContext(context.Background())
+}
+
+func (c *NitroClient) listEnabledModesWithContext(ctx context.Context) ([]byte, error) {
 	c.logger.Trace("listing modes")
 	url := c.url + "nsmode"
 
-	return c.doHTTPRequest("GET", url, bytes.NewBuffer([]byte{}), readResponseHandler)
+	return c.doHTTPRequestWithContext(ctx, "GET", url, bytes.NewBuffer([]byte{}), readResponseHandler)
 
 }
 
 func (c *NitroClient) saveConfig(saveJSON []byte) error {
+	return c.saveConfigWithContext(context.Background(), saveJSON)
+}
+
+func (c *NitroClient) saveConfigWithContext(ctx context.Context, saveJSON []byte) error {
 	c.logger.Trace("Saving config")
 	url := c.url + "nsconfig?action=save"
 
-	_, err := c.doHTTPRequest("POST", url, bytes.NewBuffer(saveJSON), createResponseHandler)
+	_, err := c.doHTTPRequestWithContext(ctx, "POST", url, bytes.NewBuffer(saveJSON), createResponseHandler)
 	return err
 
 }
 
 func (c *NitroClient) clearConfig(clearJSON []byte) error {
+	return c.clearConfigWithContext(context.Background(), clearJSON)
+}
+
+func (c *NitroClient) clearConfigWithContext(ctx context.Context, clearJSON []byte) error {
 	c.logger.Trace("Clearing config")
 	url := c.url + "nsconfig?action=clear"
 
-	_, err := c.doHTTPRequest("POST", url, bytes.NewBuffer(clearJSON), createResponseHandler)
+	_, err := c.doHTTPRequestWithContext(ctx, "POST", url, bytes.NewBuffer(clearJSON), createResponseHandler)
 	return err
 }
 
 func (c *NitroClient) listStat(resourceType, resourceName string) ([]byte, error) {
+	return c.listStatWithContext(context.Background(), resourceType, resourceName)
+}
+
+func (c *NitroClient) listStatWithContext(ctx context.Context, resourceType, resourceName string) ([]byte, error) {
 	c.logger.Trace("listing stat of type ", "resourceType", resourceType, "name", resourceName)
 	url := c.statsURL + resourceType
 
@@ -519,11 +623,15 @@ func (c *NitroClient) listStat(resourceType, resourceName string) ([]byte, error
 	}
 	c.logger.Trace("listStat", "url", url)
 
-	return c.doHTTPRequest("GET", url, bytes.NewBuffer([]byte{}), readResponseHandler)
+	return c.doHTTPRequestWithContext(ctx, "GET", url, bytes.NewBuffer([]byte{}), readResponseHandler)
 
 }
 
 func (c *NitroClient) listStatWithArgs(resourceType string, resourceName string, args []string) ([]byte, error) {
+	return c.listStatWithArgsWithContext(context.Background(), resourceType, resourceName, args)
+}
+
+func (c *NitroClient) listStatWithArgsWithContext(ctx context.Context, resourceType string, resourceName string, args []string) ([]byte, error) {
 	c.logger.Trace("listing stat ", "resourceType", resourceType, "name", resourceName, "args", args)
 	var url string
 
@@ -537,5 +645,5 @@ func (c *NitroClient) listStatWithArgs(resourceType string, resourceName string,
 	url = url + "?args=" + strArgs
 	c.logger.Trace("listStatWithArgs", "url", url)
 
-	return c.doHTTPRequest("GET", url, bytes.NewBuffer([]byte{}), readResponseHandler)
+	return c.doHTTPRequestWithContext(ctx, "GET", url, bytes.NewBuffer([]byte{}), readResponseHandler)
 }

--- a/service/netscaler_resource.go
+++ b/service/netscaler_resource.go
@@ -500,6 +500,10 @@ func (c *NitroClient) listResourceWithArgsWithContext(ctx context.Context, resou
 
 	data, err := c.doHTTPRequestWithContext(ctx, "GET", url2, bytes.NewBuffer([]byte{}), readResponseHandler)
 	if err != nil {
+		// DO NOT fallback for systemfile
+		if resourceType == "systemfile" {
+			return data, err
+		}
 		c.logger.Trace("listResourceWithArgs: error listing with args, trying filter", "error", err)
 		url2 = url + "?filter=" + strArgs
 		c.logger.Trace("listResourceWithArgs", "url2", url2)

--- a/service/stats.go
+++ b/service/stats.go
@@ -17,15 +17,21 @@ limitations under the License.
 package service
 
 import (
-	"log"
-	"fmt"
+	"context"
 	"encoding/json"
+	"fmt"
+	"log"
 )
 
-//FindStats returns the statistics of the supplied resource type if it exists. Use when the resource to be returned is an array
+// FindStats returns the statistics of the supplied resource type if it exists. Use when the resource to be returned is an array
 func (c *NitroClient) FindAllStats(resourceType string) ([]map[string]interface{}, error) {
+	return c.FindAllStatsWithContext(context.Background(), resourceType)
+}
+
+// FindAllStatsWithContext returns the statistics of the supplied resource type if it exists. Use when the resource to be returned is an array
+func (c *NitroClient) FindAllStatsWithContext(ctx context.Context, resourceType string) ([]map[string]interface{}, error) {
 	var data map[string]interface{}
-	result, err := c.listStat(resourceType, "")
+	result, err := c.listStatWithContext(ctx, resourceType, "")
 	if err != nil {
 		log.Printf("[WARN] nitro-go: FindStats: No %s found", resourceType)
 		return nil, fmt.Errorf("[INFO] nitro-go: FindStats: No type %s found", resourceType)
@@ -47,10 +53,15 @@ func (c *NitroClient) FindAllStats(resourceType string) ([]map[string]interface{
 	return ret, nil
 }
 
-//FindStat returns the config of the supplied resource name and type if it exists
+// FindStat returns the config of the supplied resource name and type if it exists
 func (c *NitroClient) FindStat(resourceType string, resourceName string) (map[string]interface{}, error) {
+	return c.FindStatWithContext(context.Background(), resourceType, resourceName)
+}
+
+// FindStatWithContext returns the config of the supplied resource name and type if it exists
+func (c *NitroClient) FindStatWithContext(ctx context.Context, resourceType string, resourceName string) (map[string]interface{}, error) {
 	var data map[string]interface{}
-	result, err := c.listStat(resourceType, resourceName)
+	result, err := c.listStatWithContext(ctx, resourceType, resourceName)
 	if err != nil {
 		log.Printf("[WARN] nitro-go: FindStat: No %s %s found", resourceType, resourceName)
 		return nil, fmt.Errorf("[INFO] nitro-go: FindStat: No resource %s of type %s found", resourceName, resourceType)
@@ -70,9 +81,12 @@ func (c *NitroClient) FindStat(resourceType string, resourceName string) (map[st
 }
 
 func (c *NitroClient) FindStatWithArgs(resourceType string, resourceName string, args []string) (map[string]interface{}, error) {
+	return c.FindStatWithArgsWithContext(context.Background(), resourceType, resourceName, args)
+}
 
+func (c *NitroClient) FindStatWithArgsWithContext(ctx context.Context, resourceType string, resourceName string, args []string) (map[string]interface{}, error) {
 	var data map[string]interface{}
-	result, err := c.listStatWithArgs(resourceType, resourceName, args)
+	result, err := c.listStatWithArgsWithContext(ctx, resourceType, resourceName, args)
 	if err != nil {
 		log.Printf("[WARN] nitro-go: FindStatWithArgs: No %s %s found", resourceType, resourceName)
 		return nil, fmt.Errorf("[INFO] nitro-go: FindStatWithArgs: No resource %s of type %s found", resourceName, resourceType)


### PR DESCRIPTION
### **Summary**
This PR adds context support across NitroClient public APIs while preserving backward compatibility for existing callers.

### **Current Behavior**
NitroClient public methods execute HTTP operations without caller-provided context, which prevents callers from attaching cancellation or deadlines.

### **New Behavior**

- Added WithContext variants for NitroClient public APIs, with context.Context as the first parameter.
- Preserved existing method signatures.
- Existing methods now delegate to their WithContext variant using context.Background().
- Propagated context through internal HTTP helper calls down to request creation and execution.
- Updated request creation to use context-aware request construction.
- Added safer handling around request creation failures to avoid nil-request usage paths.


### **Backward Compatibility**
No breaking changes.

Existing callers continue to work without modification.
New callers can opt into context-aware behavior incrementally.

### **Files Changed**

- [netscaler_resource.go](vscode-file://vscode-app/c:/Users/abdillahi.nur/AppData/Local/Programs/Microsoft%20VS%20Code/f6cfa2ea24/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
- [config.go](vscode-file://vscode-app/c:/Users/abdillahi.nur/AppData/Local/Programs/Microsoft%20VS%20Code/f6cfa2ea24/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
- [stats.go](vscode-file://vscode-app/c:/Users/abdillahi.nur/AppData/Local/Programs/Microsoft%20VS%20Code/f6cfa2ea24/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
